### PR TITLE
Updated readme to correct the folder name

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Homebrew and apt packages to come.
 
    - ```bash
      git clone git@github.com:ismet55555/bieye.git
-     cd bioread
+     cd bieye
      cargo install --path .
      bieye --help
      ```


### PR DESCRIPTION
Looks like the folder name in the readme after cloning isn't accurate (it mentions bioread instead of bieye), i updated the folder name to bieye instead of bioread.